### PR TITLE
Fixes a spelling error in kernel_compile_syscall_module.html

### DIFF
--- a/assignments/kernel_compile_syscall_module.html
+++ b/assignments/kernel_compile_syscall_module.html
@@ -192,7 +192,7 @@ struct timespec {
 The system call should verify that user memory space, pointed to by <tt>current_time</tt>,
 is valid and writable. If not, is should return a failure (EFAULT) to the user process. 
 If the memory-check succeeds, then it should retrieve the value of 
-kernel's <tt>xtime</tt> variable using <tt>current_kernel_time(...)</tt> fucntion, which will read xtime atomically 
+kernel's <tt>xtime</tt> variable using <tt>current_kernel_time(...)</tt> function, which will read xtime atomically 
 for you. Then copy the retrieved value to user space address (pointed to by current_time argument). The system call should also 
 print the current time in nanoseconds, to the console using the <tt>printk()</tt> function.
 </li>


### PR DESCRIPTION
It changes the word "fucntion" to the word "function" for assignment 2.